### PR TITLE
New Features

### DIFF
--- a/example/src/main/java/com/duartbreedt/example/MainActivity.kt
+++ b/example/src/main/java/com/duartbreedt/example/MainActivity.kt
@@ -26,7 +26,7 @@ class MainActivity : AppCompatActivity() {
             ),
             Section(
                 Section.DisplayMode.VALUE,
-                BigDecimal("10"),
+                BigDecimal("20"),
                 ContextCompat.getColor(this, R.color.blue)
             ),
             Section(
@@ -40,6 +40,6 @@ class MainActivity : AppCompatActivity() {
             )
         )
 
-        graph_layout.draw(Data(sections, BigDecimal("50")))
+        graph_layout.draw(Data(sections, BigDecimal("60")))
     }
 }

--- a/example/src/main/java/com/duartbreedt/example/MainActivity.kt
+++ b/example/src/main/java/com/duartbreedt/example/MainActivity.kt
@@ -40,6 +40,6 @@ class MainActivity : AppCompatActivity() {
             )
         )
 
-        graph_layout.draw(Data(sections, BigDecimal("50")))
+        graph_layout.draw(Data(sections, BigDecimal("40")))
     }
 }

--- a/example/src/main/java/com/duartbreedt/example/MainActivity.kt
+++ b/example/src/main/java/com/duartbreedt/example/MainActivity.kt
@@ -40,6 +40,6 @@ class MainActivity : AppCompatActivity() {
             )
         )
 
-        graph_layout.draw(Data(sections, BigDecimal("40")))
+        graph_layout.draw(Data(sections, BigDecimal("50")))
     }
 }

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -17,6 +17,7 @@
         app:labelsEnabled="true"
         app:labelsColor="@color/label_defaultColor"
         app:strokeWidth="15dp"
+        app:backgroundTrackColor="@color/black"
 
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -13,7 +13,7 @@
         android:padding="@dimen/label_margin"
 
         app:animationDirection="clockwise"
-        app:animationDuration="1000"
+        app:animationDuration="3000"
         app:capStyle="rounded"
         app:labelsEnabled="true"
         app:labelsColor="@color/label_defaultColor"

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -13,13 +13,14 @@
         android:padding="@dimen/label_margin"
 
         app:animationDirection="clockwise"
+        app:animationDuration="1000"
         app:capStyle="rounded"
         app:labelsEnabled="true"
         app:labelsColor="@color/label_defaultColor"
         app:strokeWidth="25dp"
-        app:backgroundTrackColor="@color/black"
         app:graphNode="percent"
         app:graphNodeColor="@color/grey"
+        app:backgroundTrackColor="@color/black"
 
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -13,9 +13,10 @@
         android:padding="@dimen/label_margin"
 
         app:animationDirection="clockwise"
+        app:capStyle="rounded"
         app:labelsEnabled="true"
         app:labelsColor="@color/label_defaultColor"
-        app:strokeWidth="10dp"
+        app:strokeWidth="15dp"
 
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -16,8 +16,10 @@
         app:capStyle="rounded"
         app:labelsEnabled="true"
         app:labelsColor="@color/label_defaultColor"
-        app:strokeWidth="15dp"
+        app:strokeWidth="25dp"
         app:backgroundTrackColor="@color/black"
+        app:graphNode="percent"
+        app:graphNodeColor="@color/grey"
 
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/example/src/main/res/values/colors.xml
+++ b/example/src/main/res/values/colors.xml
@@ -4,6 +4,7 @@
     <color name="colorPrimaryDark">#3700B3</color>
     <color name="colorAccent">#03DAC5</color>
 
+    <color name="black">#000</color>
     <color name="red">#FF0000</color>
     <color name="green">#00FF00</color>
     <color name="blue">#0000FF</color>

--- a/example/src/main/res/values/colors.xml
+++ b/example/src/main/res/values/colors.xml
@@ -4,6 +4,7 @@
     <color name="colorPrimaryDark">#3700B3</color>
     <color name="colorAccent">#03DAC5</color>
 
+    <color name="grey">#464646</color>
     <color name="black">#000</color>
     <color name="red">#FF0000</color>
     <color name="green">#00FF00</color>

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/GraphDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/GraphDrawable.kt
@@ -34,7 +34,7 @@ abstract class GraphDrawable(
             pathEffect = DashPathEffect(floatArrayOf(state.length!! , state.length!!), phase)
             style = Paint.Style.STROKE
             flags = Paint.ANTI_ALIAS_FLAG
-            strokeCap = Paint.Cap.BUTT
+            strokeCap = graphConfig.capStyle.paintCapStyle
         }
     }
 

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/GraphDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/GraphDrawable.kt
@@ -48,28 +48,19 @@ abstract class GraphDrawable(
         return path
     }
 
-    protected fun buildNodePath(segmentPath: Path): Path {
-        val path = Path()
-
-        val coordinates = FloatArray(2)
-        val pathMeasure = PathMeasure(segmentPath, false)
-
-        pathMeasure.getPosTan(pathMeasure.length, coordinates, null)
-        path.addCircle(coordinates[0], coordinates[1], 5f, Path.Direction.CW)
-
-        // The starting position of the arc is undesirable, therefore set it explicitly
-        rotatePath(path, startingRotation)
-        return path
-    }
-
-    protected fun buildNodePaint(state: SectionState, colorInt: Int): Paint {
+    protected fun buildNodePaint(colorInt: Int): Paint {
         return Paint().apply {
-            strokeWidth = 1f
             color = colorInt
-            pathEffect = DashPathEffect(floatArrayOf(state.length!!, state.length!!), 0f)
             style = Paint.Style.FILL
             flags = Paint.ANTI_ALIAS_FLAG
-            strokeCap = graphConfig.capStyle.paintCapStyle
+        }
+    }
+
+    protected fun buildNodeBackgroundPaint(colorInt: Int): Paint {
+        return Paint().apply {
+            color = colorInt
+            style = Paint.Style.FILL
+            flags = Paint.ANTI_ALIAS_FLAG
         }
     }
 

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/GraphDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/GraphDrawable.kt
@@ -4,13 +4,13 @@ import android.graphics.DashPathEffect
 import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
+import android.graphics.PathMeasure
 import android.graphics.PixelFormat
 import android.graphics.RectF
 import android.graphics.drawable.Drawable
+import android.text.TextPaint
 import com.duartbreedt.radialgraph.model.AnimationDirection
-import com.duartbreedt.radialgraph.model.Cap
 import com.duartbreedt.radialgraph.model.GraphConfig
-import com.duartbreedt.radialgraph.model.Section
 import com.duartbreedt.radialgraph.model.SectionState
 
 abstract class GraphDrawable(
@@ -31,7 +31,7 @@ abstract class GraphDrawable(
         return Paint().apply {
             strokeWidth = graphConfig.strokeWidth
             color = state.color
-            pathEffect = DashPathEffect(floatArrayOf(state.length!! , state.length!!), phase)
+            pathEffect = DashPathEffect(floatArrayOf(state.length!!, state.length!!), phase)
             style = Paint.Style.STROKE
             flags = Paint.ANTI_ALIAS_FLAG
             strokeCap = graphConfig.capStyle.paintCapStyle
@@ -46,6 +46,39 @@ abstract class GraphDrawable(
         // The starting position of the arc is undesirable, therefore set it explicitly
         rotatePath(path, startingRotation)
         return path
+    }
+
+    protected fun buildNodePath(segmentPath: Path): Path {
+        val path = Path()
+
+        val coordinates = FloatArray(2)
+        val pathMeasure = PathMeasure(segmentPath, false)
+
+        pathMeasure.getPosTan(pathMeasure.length, coordinates, null)
+        path.addCircle(coordinates[0], coordinates[1], 5f, Path.Direction.CW)
+
+        // The starting position of the arc is undesirable, therefore set it explicitly
+        rotatePath(path, startingRotation)
+        return path
+    }
+
+    protected fun buildNodePaint(state: SectionState, colorInt: Int): Paint {
+        return Paint().apply {
+            strokeWidth = 1f
+            color = colorInt
+            pathEffect = DashPathEffect(floatArrayOf(state.length!!, state.length!!), 0f)
+            style = Paint.Style.FILL
+            flags = Paint.ANTI_ALIAS_FLAG
+            strokeCap = graphConfig.capStyle.paintCapStyle
+        }
+    }
+
+    protected fun buildNodeTextPaint(textColor: Int, textSize: Float): Paint {
+        return TextPaint().apply {
+            this.textSize = textSize
+            color = textColor
+            flags = Paint.ANTI_ALIAS_FLAG
+        }
     }
 
     private fun rotatePath(path: Path, degrees: Float) {

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/RadialGraphDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/RadialGraphDrawable.kt
@@ -77,7 +77,7 @@ class RadialGraphDrawable(
             this,
             PROGRESS, 0f, 1f
         ).apply {
-            duration = 1000L
+            duration = graphConfig.animationDuration
             interpolator = AccelerateDecelerateInterpolator()
         }.start()
     }

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/RadialGraphDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/RadialGraphDrawable.kt
@@ -21,7 +21,6 @@ class RadialGraphDrawable(
         val boundaries = calculateBoundaries()
 
         for (sectionState in sectionStates) {
-
             if (sectionState.path == null) {
                 sectionState.path = buildCircularPath(boundaries)
             }
@@ -32,34 +31,45 @@ class RadialGraphDrawable(
 
             sectionState.paint = buildPhasedPathPaint(sectionState)
             canvas.drawPath(sectionState.path!!, sectionState.paint!!)
+        }
 
-            if (graphConfig.graphNodeType != GraphNode.NONE) {
-                if (sectionState.isLastSection) {
-                    val pathMeasure = PathMeasure(sectionState.path!!, false)
-                    val coordinates = FloatArray(2)
+        if (graphConfig.graphNodeType == GraphNode.PERCENT) {
+            val sectionState = sectionStates.first { it.isLastSection }
 
-                    // Get the position of the end of the last drawn segment
-                    pathMeasure.getPosTan(
-                        sectionState.length!! * (1 - (sectionState.sweepSize + sectionState.startPosition)),
-                        coordinates,
-                        null
-                    )
+            if (sectionState.isLastSection) {
+                val pathMeasure = PathMeasure(sectionState.path!!, false)
+                val coordinates = FloatArray(2)
 
-                    canvas.drawCircle(
-                        coordinates[0],
-                        coordinates[1],
-                        graphConfig.strokeWidth / 2,
-                        buildNodePaint(sectionState, graphConfig.graphNodeColor)
-                    )
+                // Get the position of the end of the last drawn segment
+                pathMeasure.getPosTan(
+                    sectionState.length!! * (1 - (sectionState.sweepSize + sectionState.startPosition)),
+                    coordinates,
+                    null
+                )
 
-                    // TODO: Investigate why the magic number 15f works here for centering the text within the circle
-                    canvas.drawText(
-                        "%",
-                        coordinates[0] - 15f,
-                        coordinates[1] + 15f,
-                        buildNodeTextPaint(sectionState.color, graphConfig.graphNodeTextSize)
-                    )
-                }
+                // FIXME: This is a hack. Ideally the draw order should be fixed so that the last segment is drawn on top instead of at the bottom
+                // Add a circle with the same background as the last segment drawn
+                canvas.drawCircle(
+                    coordinates[0],
+                    coordinates[1],
+                    graphConfig.strokeWidth / 2,
+                    buildNodeBackgroundPaint(sectionState.color)
+                )
+
+                canvas.drawCircle(
+                    coordinates[0],
+                    coordinates[1],
+                    (graphConfig.strokeWidth / 2) - (graphConfig.strokeWidth / 10),
+                    buildNodePaint(graphConfig.graphNodeColor)
+                )
+
+                // TODO: Investigate why the magic number 15f works here for centering the text within the circle
+                canvas.drawText(
+                    "%",
+                    coordinates[0] - 15f,
+                    coordinates[1] + 15f,
+                    buildNodeTextPaint(sectionState.color, graphConfig.graphNodeTextSize)
+                )
             }
         }
     }

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/RadialGraphDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/RadialGraphDrawable.kt
@@ -9,6 +9,7 @@ import android.util.FloatProperty
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.annotation.RequiresApi
 import com.duartbreedt.radialgraph.model.GraphConfig
+import com.duartbreedt.radialgraph.model.GraphNode
 import com.duartbreedt.radialgraph.model.SectionState
 
 class RadialGraphDrawable(
@@ -31,6 +32,35 @@ class RadialGraphDrawable(
 
             sectionState.paint = buildPhasedPathPaint(sectionState)
             canvas.drawPath(sectionState.path!!, sectionState.paint!!)
+
+            if (graphConfig.graphNodeType != GraphNode.NONE) {
+                if (sectionState.isLastSection) {
+                    val pathMeasure = PathMeasure(sectionState.path!!, false)
+                    val coordinates = FloatArray(2)
+
+                    // Get the position of the end of the last drawn segment
+                    pathMeasure.getPosTan(
+                        sectionState.length!! * (1 - (sectionState.sweepSize + sectionState.startPosition)),
+                        coordinates,
+                        null
+                    )
+
+                    canvas.drawCircle(
+                        coordinates[0],
+                        coordinates[1],
+                        graphConfig.strokeWidth / 2,
+                        buildNodePaint(sectionState, graphConfig.graphNodeColor)
+                    )
+
+                    // TODO: Investigate why the magic number 15f works here for centering the text within the circle
+                    canvas.drawText(
+                        "%",
+                        coordinates[0] - 15f,
+                        coordinates[1] + 15f,
+                        buildNodeTextPaint(sectionState.color, graphConfig.graphNodeTextSize)
+                    )
+                }
+            }
         }
     }
 

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/TrackDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/TrackDrawable.kt
@@ -27,7 +27,7 @@ class TrackDrawable(private val graphConfig: GraphConfig, private val background
             pathEffect = DashPathEffect(floatArrayOf(pathMeasure.length, pathMeasure.length), 0f)
             style = Paint.Style.STROKE
             flags = Paint.ANTI_ALIAS_FLAG
-            strokeCap = Paint.Cap.BUTT
+            strokeCap = graphConfig.capStyle.paintCapStyle
         }
 
         canvas.drawPath(path, paint)

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/TrackDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/TrackDrawable.kt
@@ -27,7 +27,7 @@ class TrackDrawable(private val graphConfig: GraphConfig, private val background
             pathEffect = DashPathEffect(floatArrayOf(pathMeasure.length, pathMeasure.length), 0f)
             style = Paint.Style.STROKE
             flags = Paint.ANTI_ALIAS_FLAG
-            strokeCap = graphConfig.capStyle.paintCapStyle
+            strokeCap = Paint.Cap.BUTT
         }
 
         canvas.drawPath(path, paint)

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/TrackDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/TrackDrawable.kt
@@ -1,0 +1,52 @@
+package com.duartbreedt.radialgraph.drawable
+
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.DashPathEffect
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.PathMeasure
+import android.graphics.PixelFormat
+import android.graphics.RectF
+import android.graphics.drawable.Drawable
+import com.duartbreedt.radialgraph.model.GraphConfig
+
+class TrackDrawable(private val graphConfig: GraphConfig, private val backgroundColor: Int) : Drawable() {
+
+    override fun draw(canvas: Canvas) {
+        val boundaries = calculateBoundaries()
+        val path = Path()
+
+        path.addCircle(boundaries.centerX(), boundaries.centerY(), boundaries.width() / 2, Path.Direction.CW)
+
+        val pathMeasure = PathMeasure(path, false)
+
+        val paint = Paint().apply {
+            strokeWidth = graphConfig.strokeWidth
+            color = backgroundColor
+            pathEffect = DashPathEffect(floatArrayOf(pathMeasure.length, pathMeasure.length), 0f)
+            style = Paint.Style.STROKE
+            flags = Paint.ANTI_ALIAS_FLAG
+            strokeCap = Paint.Cap.BUTT
+        }
+
+        canvas.drawPath(path, paint)
+    }
+
+    override fun setAlpha(alpha: Int) {
+    }
+
+    override fun getOpacity(): Int = PixelFormat.OPAQUE
+
+    override fun setColorFilter(colorFilter: ColorFilter?) {
+    }
+
+    private fun calculateBoundaries(): RectF {
+        return RectF(
+            bounds.left.toFloat() + (graphConfig.strokeWidth / 2f),
+            bounds.top.toFloat() + (graphConfig.strokeWidth / 2f),
+            bounds.right.toFloat() - (graphConfig.strokeWidth / 2f),
+            bounds.bottom.toFloat() - (graphConfig.strokeWidth / 2f)
+        )
+    }
+}

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
@@ -1,5 +1,6 @@
 package com.duartbreedt.radialgraph.model
 
+import android.view.View.NO_ID
 import androidx.annotation.ColorInt
 
 data class GraphConfig (
@@ -8,8 +9,11 @@ data class GraphConfig (
     @ColorInt val labelsColor: Int?,
     val strokeWidth: Float,
     // FIXME: Not working currently. Attend to this in https://github.com/DuartBreedt/RadialGraph/issues/6
-    val capStyle: Cap
+    val capStyle: Cap,
+    @ColorInt val backgroundTrackColor: Int
 ) {
+    val isBackgroundTrackEnabled = backgroundTrackColor != NO_ID
+
     fun isClockwise(): Boolean = animationDirection == AnimationDirection.CLOCKWISE
     fun isCounterClockwise(): Boolean = animationDirection == AnimationDirection.COUNTERCLOCKWISE
 }

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
@@ -3,14 +3,17 @@ package com.duartbreedt.radialgraph.model
 import android.view.View.NO_ID
 import androidx.annotation.ColorInt
 
-data class GraphConfig (
+data class GraphConfig(
     val animationDirection: AnimationDirection,
     val labelsEnabled: Boolean,
     @ColorInt val labelsColor: Int?,
     val strokeWidth: Float,
     // FIXME: Not working currently. Attend to this in https://github.com/DuartBreedt/RadialGraph/issues/6
     val capStyle: Cap,
-    @ColorInt val backgroundTrackColor: Int
+    @ColorInt val backgroundTrackColor: Int,
+    val graphNodeType: GraphNode,
+    @ColorInt val graphNodeColor: Int,
+    val graphNodeTextSize: Float
 ) {
     val isBackgroundTrackEnabled = backgroundTrackColor != NO_ID
 

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
@@ -5,6 +5,7 @@ import androidx.annotation.ColorInt
 
 data class GraphConfig(
     val animationDirection: AnimationDirection,
+    val animationDuration: Long,
     val labelsEnabled: Boolean,
     @ColorInt val labelsColor: Int?,
     val strokeWidth: Float,

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
@@ -9,7 +9,6 @@ data class GraphConfig(
     val labelsEnabled: Boolean,
     @ColorInt val labelsColor: Int?,
     val strokeWidth: Float,
-    // FIXME: Not working currently. Attend to this in https://github.com/DuartBreedt/RadialGraph/issues/6
     val capStyle: Cap,
     @ColorInt val backgroundTrackColor: Int,
     val graphNodeType: GraphNode,

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphNode.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphNode.kt
@@ -1,0 +1,6 @@
+package com.duartbreedt.radialgraph.model
+
+enum class GraphNode {
+    NONE,
+    PERCENT
+}

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/SectionState.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/SectionState.kt
@@ -14,7 +14,8 @@ data class SectionState(
     var length: Float? = null
 )
 
-enum class Cap {
-    BUTT,
-    ROUND
+enum class Cap(val paintCapStyle: Paint.Cap) {
+    BUTT(Paint.Cap.BUTT),
+    ROUND(Paint.Cap.ROUND),
+    SQUARE(Paint.Cap.SQUARE)
 }

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -35,7 +35,9 @@ class RadialGraph : ConstraintLayout {
 
     companion object {
         private const val CLOCKWISE_ANIMATION_DIRECTION = 0
+        private const val SQUARE_CAP_STYLE = 2
         private const val DEFAULT_ANIMATION_DIRECTION = CLOCKWISE_ANIMATION_DIRECTION
+        private const val DEFAULT_CAP_STYLE = SQUARE_CAP_STYLE
     }
 
     init {
@@ -63,12 +65,15 @@ class RadialGraph : ConstraintLayout {
 
         val strokeWidth: Float = attributes.getDimension(R.styleable.RadialGraph_strokeWidth, 0f)
 
+        val capStyleOrdinal: Int = attributes.getInt(R.styleable.RadialGraph_capStyle, DEFAULT_CAP_STYLE)
+        val capStyle = Cap.values()[capStyleOrdinal]
+
         graphConfig = GraphConfig(
             animationDirection,
             labelsEnabled,
             labelsColor,
             strokeWidth,
-            Cap.ROUND
+            capStyle
         )
 
         attributes.recycle()

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -1,21 +1,20 @@
 package com.duartbreedt.radialgraph.view
 
 import android.content.Context
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.LayerDrawable
 import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
-import androidx.constraintlayout.widget.ConstraintSet.BOTTOM
-import androidx.constraintlayout.widget.ConstraintSet.LEFT
-import androidx.constraintlayout.widget.ConstraintSet.PARENT_ID
-import androidx.constraintlayout.widget.ConstraintSet.RIGHT
-import androidx.constraintlayout.widget.ConstraintSet.TOP
+import androidx.constraintlayout.widget.ConstraintSet.*
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import com.duartbreedt.radialgraph.R
 import com.duartbreedt.radialgraph.drawable.RadialGraphDrawable
+import com.duartbreedt.radialgraph.drawable.TrackDrawable
 import com.duartbreedt.radialgraph.extensions.toFormattedDecimal
 import com.duartbreedt.radialgraph.model.AnimationDirection
 import com.duartbreedt.radialgraph.model.Cap
@@ -68,12 +67,15 @@ class RadialGraph : ConstraintLayout {
         val capStyleOrdinal: Int = attributes.getInt(R.styleable.RadialGraph_capStyle, DEFAULT_CAP_STYLE)
         val capStyle = Cap.values()[capStyleOrdinal]
 
+        val backgroundTrackColor = attributes.getColor(R.styleable.RadialGraph_backgroundTrackColor, View.NO_ID)
+
         graphConfig = GraphConfig(
             animationDirection,
             labelsEnabled,
             labelsColor,
             strokeWidth,
-            capStyle
+            capStyle,
+            backgroundTrackColor
         )
 
         attributes.recycle()
@@ -121,11 +123,20 @@ class RadialGraph : ConstraintLayout {
     }
 
     private fun drawGraph(data: Data) {
+        val layers = mutableListOf<Drawable>()
+
+        if (graphConfig.isBackgroundTrackEnabled) {
+            val backgroundTrack = TrackDrawable(graphConfig, graphConfig.backgroundTrackColor)
+            layers.add(backgroundTrack)
+        }
 
         // TODO: Perhaps don't reverse this here and just sort differently a bit higher
         val graph = RadialGraphDrawable(graphConfig, data.toSectionStates().reversed())
+        layers.add(graph)
 
-        graphView!!.setImageDrawable(graph)
+        val finalDrawable = LayerDrawable(layers.toTypedArray())
+
+        graphView!!.setImageDrawable(finalDrawable)
 
         graph.animateIn()
     }

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -37,12 +37,12 @@ class RadialGraph : ConstraintLayout {
     companion object {
         private val TAG = RadialGraph::class.simpleName!!
 
-        private const val CLOCKWISE_ANIMATION_DIRECTION = 0
-        private const val SQUARE_CAP_STYLE = 2
+        private const val ANIMATION_DIRECTION_CLOCKWISE = 0
+        private const val CAP_STYLE_BUTT = 0
         private const val GRAPH_NODE_NONE = 0
 
-        private const val DEFAULT_ANIMATION_DIRECTION = CLOCKWISE_ANIMATION_DIRECTION
-        private const val DEFAULT_CAP_STYLE = SQUARE_CAP_STYLE
+        private const val DEFAULT_ANIMATION_DIRECTION = ANIMATION_DIRECTION_CLOCKWISE
+        private const val DEFAULT_CAP_STYLE = CAP_STYLE_BUTT
         private const val DEFAULT_GRAPH_NODE = GRAPH_NODE_NONE
         private const val DEFAULT_ANIMATION_DURATION = 1000
     }
@@ -164,9 +164,7 @@ class RadialGraph : ConstraintLayout {
         val graph = RadialGraphDrawable(graphConfig, data.toSectionStates().reversed())
         layers.add(graph)
 
-        val finalDrawable = LayerDrawable(layers.toTypedArray())
-
-        graphView!!.setImageDrawable(finalDrawable)
+        graphView!!.setImageDrawable(LayerDrawable(layers.toTypedArray()))
 
         graph.animateIn()
     }
@@ -178,7 +176,6 @@ class RadialGraph : ConstraintLayout {
             if (graphConfig.isClockwise()) BigDecimal.ONE
             else BigDecimal.ZERO
 
-        // val wot = data.sections.reversed()
         for (section in data.sections) {
             context?.let { context ->
 

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -44,6 +44,7 @@ class RadialGraph : ConstraintLayout {
         private const val DEFAULT_ANIMATION_DIRECTION = CLOCKWISE_ANIMATION_DIRECTION
         private const val DEFAULT_CAP_STYLE = SQUARE_CAP_STYLE
         private const val DEFAULT_GRAPH_NODE = GRAPH_NODE_NONE
+        private const val DEFAULT_ANIMATION_DURATION = 1000
     }
 
     init {
@@ -59,6 +60,8 @@ class RadialGraph : ConstraintLayout {
         val animationDirectionOrdinal: Int =
             attributes.getInt(R.styleable.RadialGraph_animationDirection, DEFAULT_ANIMATION_DIRECTION)
         val animationDirection: AnimationDirection = AnimationDirection.values()[animationDirectionOrdinal]
+
+        val animationDuration: Long = attributes.getInt(R.styleable.RadialGraph_animationDuration, DEFAULT_ANIMATION_DURATION).toLong()
 
         val labelsEnabled: Boolean = attributes.getBoolean(R.styleable.RadialGraph_labelsEnabled, false)
 
@@ -94,6 +97,7 @@ class RadialGraph : ConstraintLayout {
 
         graphConfig = GraphConfig(
             animationDirection,
+            animationDuration,
             labelsEnabled,
             labelsColor,
             strokeWidth,

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.util.AttributeSet
+import android.util.Log
 import android.view.View
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.AppCompatImageView
@@ -20,6 +21,7 @@ import com.duartbreedt.radialgraph.model.AnimationDirection
 import com.duartbreedt.radialgraph.model.Cap
 import com.duartbreedt.radialgraph.model.Data
 import com.duartbreedt.radialgraph.model.GraphConfig
+import com.duartbreedt.radialgraph.model.GraphNode
 import com.duartbreedt.radialgraph.model.Section
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -33,10 +35,15 @@ class RadialGraph : ConstraintLayout {
     //endregion
 
     companion object {
+        private val TAG = RadialGraph::class.simpleName!!
+
         private const val CLOCKWISE_ANIMATION_DIRECTION = 0
         private const val SQUARE_CAP_STYLE = 2
+        private const val GRAPH_NODE_NONE = 0
+
         private const val DEFAULT_ANIMATION_DIRECTION = CLOCKWISE_ANIMATION_DIRECTION
         private const val DEFAULT_CAP_STYLE = SQUARE_CAP_STYLE
+        private const val DEFAULT_GRAPH_NODE = GRAPH_NODE_NONE
     }
 
     init {
@@ -69,13 +76,32 @@ class RadialGraph : ConstraintLayout {
 
         val backgroundTrackColor = attributes.getColor(R.styleable.RadialGraph_backgroundTrackColor, View.NO_ID)
 
+        val graphNodeOrdinal: Int = attributes.getInt(R.styleable.RadialGraph_graphNode, DEFAULT_GRAPH_NODE)
+        val graphNode = GraphNode.values()[graphNodeOrdinal]
+
+        val graphNodeColor: Int = if (attributes.hasValue(R.styleable.RadialGraph_graphNodeColor)) {
+            attributes.getColor(
+                R.styleable.RadialGraph_graphNodeColor,
+                ContextCompat.getColor(context, R.color.node_defaultColor)
+            )
+        } else {
+            if (graphNode != GraphNode.NONE) {
+                Log.w(TAG, "No value passed for the `app:graphNodeColor` attribute. It will default to Magenta")
+            }
+
+            ContextCompat.getColor(context, R.color.node_defaultColor)
+        }
+
         graphConfig = GraphConfig(
             animationDirection,
             labelsEnabled,
             labelsColor,
             strokeWidth,
             capStyle,
-            backgroundTrackColor
+            backgroundTrackColor,
+            graphNode,
+            graphNodeColor,
+            context.resources.getDimension(R.dimen.node_defaultTextSize)
         )
 
         attributes.recycle()

--- a/radialgraph/src/main/res/values/attrs.xml
+++ b/radialgraph/src/main/res/values/attrs.xml
@@ -18,6 +18,7 @@
 
     <declare-styleable name="RadialGraph">
         <attr name="animationDirection" />
+        <attr name="animationDuration" format="integer" />
         <attr name="capStyle" />
         <attr name="graphNode" />
         <attr name="graphNodeColor" format="color" />

--- a/radialgraph/src/main/res/values/attrs.xml
+++ b/radialgraph/src/main/res/values/attrs.xml
@@ -11,9 +11,16 @@
         <enum name="square" value="2" />
     </attr>
 
+    <attr name="graphNode" format="enum">
+        <enum name="none" value="0" />
+        <enum name="percent" value="1" />
+    </attr>
+
     <declare-styleable name="RadialGraph">
         <attr name="animationDirection" />
         <attr name="capStyle" />
+        <attr name="graphNode" />
+        <attr name="graphNodeColor" format="color" />
         <attr name="backgroundTrackColor" format="color"/>
         <attr name="labelsEnabled" format="boolean"/>
         <attr name="labelsColor" format="color"/>

--- a/radialgraph/src/main/res/values/attrs.xml
+++ b/radialgraph/src/main/res/values/attrs.xml
@@ -23,7 +23,7 @@
         <!-- The duration (in ms) that the graph animation runs for. Defaults to 1000 -->
         <attr name="animationDuration" format="integer" />
 
-        <!-- The cap style that the graph segment is drawn with. Defaults to square -->
+        <!-- The cap style that the graph segment is drawn with. Defaults to butt -->
         <attr name="capStyle" />
 
         <!-- Used to specify whether the graph should render a node on the last segment. Defaults to none -->

--- a/radialgraph/src/main/res/values/attrs.xml
+++ b/radialgraph/src/main/res/values/attrs.xml
@@ -5,8 +5,15 @@
         <enum name="counterclockwise" value="1" />
     </attr>
 
+    <attr name="capStyle" format="enum">
+        <enum name="butt" value="0" />
+        <enum name="rounded" value="1" />
+        <enum name="square" value="2" />
+    </attr>
+
     <declare-styleable name="RadialGraph">
         <attr name="animationDirection" />
+        <attr name="capStyle" />
         <attr name="labelsEnabled" format="boolean"/>
         <attr name="labelsColor" format="color"/>
         <attr name="strokeWidth" format="dimension"/>

--- a/radialgraph/src/main/res/values/attrs.xml
+++ b/radialgraph/src/main/res/values/attrs.xml
@@ -17,14 +17,31 @@
     </attr>
 
     <declare-styleable name="RadialGraph">
+        <!-- The direction in which the graph is animated in -->
         <attr name="animationDirection" />
+
+        <!-- The duration (in ms) that the graph animation runs for. Defaults to 1000 -->
         <attr name="animationDuration" format="integer" />
+
+        <!-- The cap style that the graph segment is drawn with. Defaults to square -->
         <attr name="capStyle" />
+
+        <!-- Used to specify whether the graph should render a node on the last segment. Defaults to none -->
         <attr name="graphNode" />
+
+        <!-- The color of the node being rendered on the last graph segment. Defaults to magenta -->
         <attr name="graphNodeColor" format="color" />
+
+        <!-- The colour of the background track rendered behind the graph segments. If not defined, the graph will not render a background track -->
         <attr name="backgroundTrackColor" format="color"/>
+
+        <!-- Specify whether the graph should render label views or not. Defaults to false -->
         <attr name="labelsEnabled" format="boolean"/>
+
+        <!-- Specify the colour that the label text is set to -->
         <attr name="labelsColor" format="color"/>
+
+        <!-- Specify the stroke width of the graph being drawn -->
         <attr name="strokeWidth" format="dimension"/>
     </declare-styleable>
 </resources>

--- a/radialgraph/src/main/res/values/attrs.xml
+++ b/radialgraph/src/main/res/values/attrs.xml
@@ -14,6 +14,7 @@
     <declare-styleable name="RadialGraph">
         <attr name="animationDirection" />
         <attr name="capStyle" />
+        <attr name="backgroundTrackColor" format="color"/>
         <attr name="labelsEnabled" format="boolean"/>
         <attr name="labelsColor" format="color"/>
         <attr name="strokeWidth" format="dimension"/>

--- a/radialgraph/src/main/res/values/colors.xml
+++ b/radialgraph/src/main/res/values/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="label_defaultColor">#555555</color>
+    <color name="node_defaultColor">#FF00FF</color>
 </resources>

--- a/radialgraph/src/main/res/values/dimens.xml
+++ b/radialgraph/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="label_defaultTextSize">14sp</dimen>
     <dimen name="label_padding">30dp</dimen>
+    <dimen name="node_defaultTextSize">14sp</dimen>
 </resources>


### PR DESCRIPTION
This PR contains 4 new features that were added to the `RadialGraph` which are detailed below.

## Caveats
* The graph node feature (3) uses a couple of magic numbers that will need to be investigated (however they work for all stroke width's I've tested with). 
* Ideally, the graph node should animate in with the graph segment (but it is not at the moment)

## 1. Ability to toggle the Cap Style

You are now able to specify which cap style you want the graph to be drawn with.

### 1.1 Associated Attributes
* `app:capStyle` - This is an enum attribute with the possible values being: `butt`, `rounded`, and `square`. The graph will default to `square` if this attribute is not defined

### 1.2 Examples

#### 1.2.1 Butt Cap Style
![image](https://user-images.githubusercontent.com/52398157/93876292-e8f82980-fcd6-11ea-8d21-6ed5a1ff4e1f.png)

#### 1.2.2 Square Cap Style
![image](https://user-images.githubusercontent.com/52398157/93876372-0b8a4280-fcd7-11ea-92a2-a1ba9382fa40.png)

#### 1.2.3 Rounded Cap Style
![image](https://user-images.githubusercontent.com/52398157/93876430-2492f380-fcd7-11ea-82e8-4833f77b8244.png)


## 2. Ability to add a background track
You are now able to specify a colour to be used as a background track behind the graph segments

### 2.1 Associated Attributes
* `app:backgroundTrackColor` - A color reference attribute that will set the background track of the graph. If this attribute is not defined, the graph will not render a background track

### 2.2 Examples
In this example, the background track is set to black and can be seen at the incomplete section of the graph.

![image](https://user-images.githubusercontent.com/52398157/93876649-789dd800-fcd7-11ea-9fb6-c826305cd108.png)

## 3. Ability to add a node to the last segment that is drawn

You are now able to specify a couple of parameters so that the graph will be drawn with a node at the end of it's last segment.

### 3.1 Associated Attributes
* `app:graphNode` - An enum attribute with the possible values being: `none` and `percent`. If this attribute is not defined, it will default to `none`
* `app:graphNodeColor` - A color reference attribute that allows you to specify what colour the node should be drawn with. If you set the `app:graphNode` to any value other than `none` and do not define this attribute, the graph will default to using magenta, and a warning will be output to the application logs.

### 3.2 Examples

![image](https://user-images.githubusercontent.com/52398157/93877046-1a252980-fcd8-11ea-9911-e31cd2971302.png)

## 4. Animation Duration
You are now able to specify the duration (in ms) of the animation for the graph.

### 4.1 Associated Attributes
* `app:animationDuration` - An integer attribute that sets the duration (in ms) of the graph animation. If this attribute is not defined, it defaults to `1000`