### PR TITLE
Feature: Sweep Gradient Implementation

### DIFF
--- a/example/src/main/java/com/duartbreedt/example/DataSets.kt
+++ b/example/src/main/java/com/duartbreedt/example/DataSets.kt
@@ -20,7 +20,7 @@ object DataSets {
             ),
             Section(
                 BigDecimal("35"),
-                Color.parseColor("#FEAA85")
+                Color.parseColor("#FEAA85"), Color.parseColor("#FB716F")
             ),
             Section(
                 "STAB",
@@ -45,7 +45,7 @@ object DataSets {
             Section(
                 Section.DisplayMode.PERCENT,
                 BigDecimal("75"),
-                Color.parseColor("#CE3E61")
+                Color.parseColor("#CE3E61"), Color.parseColor("#FB716F"), Color.parseColor("#FDC0A1")
             )
         )
     )

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -86,6 +86,9 @@
             app:labelsColor="@color/label_defaultColor"
             app:labelsEnabled="true"
 
+            app:gradientType="sweep"
+            app:gradientFill="section"
+
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/GraphDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/GraphDrawable.kt
@@ -5,9 +5,7 @@ import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.PixelFormat
-import android.graphics.RadialGradient
 import android.graphics.RectF
-import android.graphics.Shader.TileMode
 import android.graphics.SweepGradient
 import android.graphics.drawable.Drawable
 import android.text.TextPaint

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/RadialGraphDrawable.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/RadialGraphDrawable.kt
@@ -98,7 +98,7 @@ class RadialGraphDrawable(
                 graphEndCoords[0],
                 graphEndCoords[1],
                 strokeRadius,
-                buildFillPaint(lastSectionState.color)
+                buildFillPaint(lastSectionState.color.first())
             )
         }
 
@@ -126,7 +126,7 @@ class RadialGraphDrawable(
         lastSectionState: SectionState,
         innerCircleRadius: Float
     ) {
-        graphConfig.graphNodeIcon?.setTint(lastSectionState.color)
+        graphConfig.graphNodeIcon?.setTint(lastSectionState.color.first())
         graphConfig.graphNodeIcon?.toBitmap()?.let {
 
             // Ensures we retains the icon aspect ratio
@@ -150,7 +150,7 @@ class RadialGraphDrawable(
 
     private fun drawTextNode(canvas: Canvas, graphEndCoords: FloatArray, lastSectionState: SectionState, node: Char) {
         val nodeBounds = Rect()
-        val nodePaint = buildNodeTextPaint(lastSectionState.color, graphConfig.graphNodeTextSize).apply {
+        val nodePaint = buildNodeTextPaint(lastSectionState.color.first(), graphConfig.graphNodeTextSize).apply {
             getTextBounds(node.toString(), 0, node.toString().length, nodeBounds)
         }
         val nodeOffset: Int = nodeBounds.width() / 2

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Data.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Data.kt
@@ -48,8 +48,7 @@ class Data(sections: List<Section>, total: BigDecimal? = null) {
                     section.normalizedValue.toFloat(),
                     previousSectionEndPosition,
                     section.color,
-                    index == sections.size - 1,
-                    section.gradientColors
+                    index == sections.size - 1
                 )
 
             previousSectionEndPosition += section.normalizedValue.toFloat()

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Data.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Data.kt
@@ -37,12 +37,19 @@ class Data(sections: List<Section>, total: BigDecimal? = null) {
 
         sections.forEachIndexed { index: Int, section: Section ->
             val sectionState: SectionState =
-                if (section.value == BigDecimal.ZERO) SectionState(0f, 0f, section.color, index == sections.size - 1)
+                if (section.value == BigDecimal.ZERO) SectionState(
+                    0f,
+                    0f,
+                    section.color,
+                    index == sections.size - 1,
+                    section.gradientColors
+                )
                 else SectionState(
                     section.normalizedValue.toFloat(),
                     previousSectionEndPosition,
                     section.color,
-                    index == sections.size - 1
+                    index == sections.size - 1,
+                    section.gradientColors
                 )
 
             previousSectionEndPosition += section.normalizedValue.toFloat()

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Gradient.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Gradient.kt
@@ -1,0 +1,11 @@
+package com.duartbreedt.radialgraph.model
+
+enum class GradientType {
+    NONE,
+    SWEEP
+}
+
+enum class GradientFill {
+    SECTION,
+    FULL
+}

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
@@ -16,11 +16,15 @@ data class GraphConfig(
     var graphNodeType: GraphNode,
     @ColorInt val graphNodeColor: Int,
     val graphNodeTextSize: Float,
-    val graphNodeIcon: Drawable?
+    val graphNodeIcon: Drawable?,
+    val gradientType: GradientType,
+    val gradientFill: GradientFill
 ) {
     val isBackgroundTrackEnabled: Boolean
         get() = backgroundTrackColor != NO_ID || backgroundTrackDrawable != null
 
     fun isClockwise(): Boolean = animationDirection == AnimationDirection.CLOCKWISE
     fun isCounterClockwise(): Boolean = animationDirection == AnimationDirection.COUNTERCLOCKWISE
+
+    fun isGradientEnabled(): Boolean = gradientType != GradientType.NONE
 }

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Section.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Section.kt
@@ -9,29 +9,34 @@ class Section {
     val value: BigDecimal
     @ColorInt
     val color: Int
+    @ColorInt
+    val gradientColors: List<Int>?
     lateinit var totalValue: BigDecimal
     lateinit var normalizedValue: BigDecimal
     lateinit var percent: BigDecimal
 
-    constructor(value: BigDecimal, color: Int) {
+    constructor(value: BigDecimal, color: Int, gradientColors: List<Int>? = null) {
         this.label = null
         this.displayMode = DisplayMode.PERCENT
         this.value = value
         this.color = color
+        this.gradientColors = gradientColors
     }
 
-    constructor(label: String, value: BigDecimal, color: Int) {
+    constructor(label: String, value: BigDecimal, color: Int, gradientColors: List<Int>? = null) {
         this.label = label
         this.displayMode = DisplayMode.PERCENT
         this.value = value
         this.color = color
+        this.gradientColors = gradientColors
     }
 
-    constructor(displayMode: DisplayMode, value: BigDecimal, color: Int) {
+    constructor(displayMode: DisplayMode, value: BigDecimal, color: Int, gradientColors: List<Int>? = null) {
         this.label = null
         this.displayMode = displayMode
         this.value = value
         this.color = color
+        this.gradientColors = gradientColors
     }
 
     enum class DisplayMode {

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Section.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/Section.kt
@@ -1,6 +1,7 @@
 package com.duartbreedt.radialgraph.model
 
 import androidx.annotation.ColorInt
+import java.lang.IllegalArgumentException
 import java.math.BigDecimal
 
 class Section {
@@ -9,30 +10,34 @@ class Section {
     val value: BigDecimal
 
     @ColorInt
-    val color: Int
+    val color: List<Int>
     lateinit var totalValue: BigDecimal
     lateinit var normalizedValue: BigDecimal
     lateinit var percent: BigDecimal
 
-    constructor(value: BigDecimal, color: Int) {
+    companion object {
+        private const val EMPTY_COLOR_EXCEPTION = "Color can not be empty!"
+    }
+
+    constructor(value: BigDecimal, vararg color: Int) {
         this.label = null
         this.displayMode = DisplayMode.PERCENT
         this.value = value
-        this.color = color
+        this.color = if(color.isEmpty()) throw IllegalArgumentException(EMPTY_COLOR_EXCEPTION) else color.toList()
     }
 
-    constructor(label: String, value: BigDecimal, color: Int) {
+    constructor(label: String, value: BigDecimal, vararg color: Int) {
         this.label = label
         this.displayMode = DisplayMode.PERCENT
         this.value = value
-        this.color = color
+        this.color = if(color.isEmpty()) throw IllegalArgumentException(EMPTY_COLOR_EXCEPTION) else color.toList()
     }
 
-    constructor(displayMode: DisplayMode, value: BigDecimal, color: Int) {
+    constructor(displayMode: DisplayMode, value: BigDecimal, vararg color: Int) {
         this.label = null
         this.displayMode = displayMode
         this.value = value
-        this.color = color
+        this.color = if(color.isEmpty()) throw IllegalArgumentException(EMPTY_COLOR_EXCEPTION) else color.toList()
     }
 
     enum class DisplayMode {

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/SectionState.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/SectionState.kt
@@ -11,7 +11,7 @@ data class SectionState(
     // The start position of this section's sweep as a value between 0.0 and 1.0
     val startPosition: Float,
 
-    val color: Int,
+    val color: List<Int>,
     val isLastSection: Boolean,
 
     // Measured section progress length

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/SectionState.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/SectionState.kt
@@ -8,6 +8,7 @@ data class SectionState(
     val startPosition: Float,
     val color: Int,
     val isLastSection: Boolean,
+    val gradientColors: List<Int>? = null,
     var currentProgress: Float = 0f,
     var path: Path? = null,
     var paint: Paint? = null,

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -43,11 +43,15 @@ class RadialGraph : ConstraintLayout {
         private const val ANIMATION_DIRECTION_CLOCKWISE = 0
         private const val CAP_STYLE_BUTT = 0
         private const val GRAPH_NODE_NONE = 0
+        private const val GRADIENT_TYPE_NONE = 0
+        private const val GRADIENT_FILL = 0
 
         private const val DEFAULT_ANIMATION_DIRECTION = ANIMATION_DIRECTION_CLOCKWISE
         private const val DEFAULT_CAP_STYLE = CAP_STYLE_BUTT
         private const val DEFAULT_GRAPH_NODE = GRAPH_NODE_NONE
         private const val DEFAULT_ANIMATION_DURATION = 1000
+        private const val DEFAULT_GRADIENT_TYPE = GRADIENT_TYPE_NONE
+        private const val DEFAULT_GRADIENT_FILL = GRADIENT_FILL
     }
 
     init {
@@ -120,6 +124,12 @@ class RadialGraph : ConstraintLayout {
             Log.e(TAG, "No value passed for the `app:graphNodeIcon` attribute.")
         }
 
+        val gradientTypeOrdinal = attributes.getInt(R.styleable.RadialGraph_gradientType, DEFAULT_GRADIENT_TYPE)
+        val gradientType = GradientType.values()[gradientTypeOrdinal]
+
+        val gradientFillOrdinal = attributes.getInt(R.styleable.RadialGraph_gradientFill, DEFAULT_GRADIENT_FILL)
+        val gradientFill = GradientFill.values()[gradientFillOrdinal]
+
         graphConfig = GraphConfig(
             animationDirection,
             animationDuration,
@@ -132,7 +142,9 @@ class RadialGraph : ConstraintLayout {
             graphNode,
             graphNodeColor,
             context.resources.getDimension(R.dimen.node_defaultTextSize),
-            graphNodeIcon
+            graphNodeIcon,
+            gradientType,
+            gradientFill
         )
 
         attributes.recycle()

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -25,6 +25,8 @@ import com.duartbreedt.radialgraph.extensions.toFormattedDecimal
 import com.duartbreedt.radialgraph.model.AnimationDirection
 import com.duartbreedt.radialgraph.model.Cap
 import com.duartbreedt.radialgraph.model.Data
+import com.duartbreedt.radialgraph.model.GradientFill
+import com.duartbreedt.radialgraph.model.GradientType
 import com.duartbreedt.radialgraph.model.GraphConfig
 import com.duartbreedt.radialgraph.model.GraphNode
 import com.duartbreedt.radialgraph.model.Section
@@ -293,7 +295,7 @@ class RadialGraph : ConstraintLayout {
                 }
 
                 @ColorInt
-                val labelColor: Int = graphConfig.labelsColor ?: section.color
+                val labelColor: Int = graphConfig.labelsColor ?: section.color.first()
 
                 val labelView = LabelView(context, labelValue, labelColor, labelPositionValue)
 

--- a/radialgraph/src/main/res/values/attrs.xml
+++ b/radialgraph/src/main/res/values/attrs.xml
@@ -17,6 +17,16 @@
         <enum name="icon" value="2" />
     </attr>
 
+    <attr name="gradientType" format="enum">
+        <enum name="none" value="0" />
+        <enum name="sweep" value="1" />
+    </attr>
+
+    <attr name="gradientFill" format="enum">
+        <enum name="section" value="0" />
+        <enum name="full" value="1" />
+    </attr>
+
     <declare-styleable name="RadialGraph">
         <!-- The direction in which the graph is animated in -->
         <attr name="animationDirection" />
@@ -50,5 +60,11 @@
 
         <!-- Specify the stroke width of the graph being drawn -->
         <attr name="strokeWidth" format="dimension"/>
+
+        <!-- Used to specify whether the graph should use apply a gradient to a section. Defaults to none -->
+        <attr name="gradientType" />
+
+        <!-- Used to specify how the gradient will be filled within a section. Defaults to section -->
+        <attr name="gradientFill" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This PR contains changes to accommodate the use of a gradient fill on graph section.

## Sweep Gradient Implementation

- Added attributes for `gradientType`
- - `NONE` - no gradient will be applied (default value)
- - `SWEEP` - apply a sweep gradient using list of `gradientColors` supplied (will apply normal color stroke if list is empty)


- Added attributes for `gradientFill`
- - `SECTION` - will apply the complete gradient scheme to percentage of the section that is shown (default value)
- - `FULL` - will apply to the gradient scheme to a 360 degree arc, if the section is less than 360, some colors may not be shown


The gradient implementation uses a sweep gradient to apply the color scheme onto an arc.
If `gradientFill` is set to `SECTION`, a position list is calculated to ensure that all colors are correctly proportioned in order to be visible in an arc.

<img src="https://github.com/DuartBreedt/RadialGraph/assets/47508305/1ec96c21-cff2-4e99-a2aa-80ff2b017c54" width="300px" />
<img src="https://github.com/DuartBreedt/RadialGraph/assets/47508305/909b93c0-71d7-49fc-82aa-4c30660a1a31" width="300px" />

An additional fix was applied to ensure that the starting Cap color doesn't include the last color in the gradient.

<img src="https://github.com/DuartBreedt/RadialGraph/assets/47508305/c56e1894-91d7-4213-893b-0da4a3c3ce84" width="300px" />
