### PR TITLE
Removed kotlin-stdlib-jdk7 dependency

### DIFF
--- a/radialgraph/build.gradle
+++ b/radialgraph/build.gradle
@@ -45,7 +45,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 }


### PR DESCRIPTION
Removed `implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"` due to issues integrating with other projects.

<img src="https://github.com/DuartBreedt/RadialGraph/assets/47508305/bd3497ec-ab9f-48b7-a225-25dd2f9b9d07" width="320px" />

### Testing:
- Sample app builds/runs without errors
<img src="https://github.com/DuartBreedt/RadialGraph/assets/47508305/4261e890-b220-417b-a80b-d7c7b0fc642b" width="320px" />
