### PR TITLE
Exposed graphNodeColor, graphNodeIcon and strokeWidth for modification

### DIFF
--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/node/IconNodeDecorator.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/node/IconNodeDecorator.kt
@@ -20,8 +20,8 @@ internal class IconNodeDecorator(@ColorInt val color: Int, node: Node, graphConf
 
         if (graphConfig.graphNodeIcon != null && drawableHashCode != graphConfig.graphNodeIcon.hashCode()) {
 
-            graphConfig.graphNodeIcon.setTint(color)
-            nodeIconBitmap = graphConfig.graphNodeIcon.toBitmap()
+            graphConfig.graphNodeIcon?.setTint(color)
+            nodeIconBitmap = graphConfig.graphNodeIcon?.toBitmap()
 
             // Ensures we retains the icon aspect ratio
             with(nodeIconBitmap!!) {

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/node/IconNodeDecorator.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/drawable/node/IconNodeDecorator.kt
@@ -24,9 +24,9 @@ internal class IconNodeDecorator(@ColorInt val color: Int, node: Node, graphConf
             nodeIconBitmap = graphConfig.graphNodeIcon?.toBitmap()
 
             // Ensures we retains the icon aspect ratio
-            with(nodeIconBitmap!!) {
-                nodeIconBitmapWidthMultiplier = if (width > height) 1.0f else width.toFloat() / height
-                nodeIconBitmapHeightMultiplier = if (width > height) height.toFloat() / width else 1.0f
+            nodeIconBitmap?.let {
+                nodeIconBitmapWidthMultiplier = if (it.width > it.height) 1.0f else it.width.toFloat() / it.height
+                nodeIconBitmapHeightMultiplier = if (it.width > it.height) it.height.toFloat() / it.width else 1.0f
             }
 
             drawableHashCode = graphConfig.graphNodeIcon.hashCode()

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
@@ -14,9 +14,9 @@ internal data class GraphConfig(
     @ColorInt var backgroundTrackColor: Int,
     var backgroundTrackDrawable: Drawable?,
     var graphNodeType: GraphNode,
-    @ColorInt val graphNodeColor: Int,
+    @ColorInt var graphNodeColor: Int,
     val graphNodeTextSize: Float,
-    val graphNodeIcon: Drawable?,
+    var graphNodeIcon: Drawable?,
     val gradientType: GradientType,
     val gradientFill: GradientFill
 ) {

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/model/GraphConfig.kt
@@ -9,7 +9,7 @@ internal data class GraphConfig(
     val animationDuration: Long,
     var labelsEnabled: Boolean,
     @ColorInt val labelsColor: Int?,
-    val strokeWidth: Float,
+    var strokeWidth: Float,
     val capStyle: Cap,
     @ColorInt var backgroundTrackColor: Int,
     var backgroundTrackDrawable: Drawable?,

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import androidx.annotation.ColorInt
+import androidx.annotation.Dimension
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.constraintlayout.widget.ConstraintSet.*
@@ -157,6 +158,10 @@ class RadialGraph : ConstraintLayout {
         if (graphConfig.labelsEnabled) {
             addLabelViewsToLayout(data)
         }
+    }
+
+    fun setStrokeWidth(@Dimension width: Float) {
+        graphConfig.strokeWidth = width
     }
 
     fun setGraphNode(newGraphNodeType: GraphNode) {

--- a/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
+++ b/radialgraph/src/main/java/com/duartbreedt/radialgraph/view/RadialGraph.kt
@@ -163,6 +163,14 @@ class RadialGraph : ConstraintLayout {
         graphConfig.graphNodeType = newGraphNodeType
     }
 
+    fun setGraphNodeColor(@ColorInt newColor: Int) {
+        graphConfig.graphNodeColor = newColor
+    }
+
+    fun setGraphNodeIcon(icon: Drawable?) {
+        graphConfig.graphNodeIcon = icon
+    }
+
     /**
      * Set the background track of the graph programmatically.
      *


### PR DESCRIPTION
Implemented a small change to allow the `graphNodeColor`, `graphNodeIcon` and `strokeWidth` config values to be  modified programmatically.